### PR TITLE
Support for  temporal  query params

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "python-envs.pythonProjects": [
+    {
+      "path": "src",
+      "envManager": "ms-python.python:venv",
+      "packageManager": "ms-python.python:pip",
+      "workspace": "esg_fastapi"
+    },
+    {
+      "path": "",
+      "envManager": "ms-python.python:venv",
+      "packageManager": "ms-python.python:pip"
+    }
+  ]
+}

--- a/features/ESGSearch_Parity/esg_search_parity.feature
+++ b/features/ESGSearch_Parity/esg_search_parity.feature
@@ -17,3 +17,9 @@ Feature: ESG Search Request/Response parity
             | minimal_response.json          |
             | multiple_projects.json         |
             | multiple_data_nodes.json       |
+            | min_version_query.json         |
+            | max_version_query.json         |
+            | min_and_max_version_query.json |
+            | from_query.json                |
+            | to_query.json                  |
+            | from_and_to_query.json         |

--- a/src/esg_fastapi/api/main.py
+++ b/src/esg_fastapi/api/main.py
@@ -10,9 +10,8 @@ from esg_fastapi.api.routes import router
 def app_factory() -> FastAPIWithSearchClient:
     """Create the FastAPI application and mount the sub-applications."""
     api = FastAPIWithSearchClient(
-        title="ESGF FastAPI",
+        title="ESGF 1.5 Bridge API",
         summary="An adapter service to translate and execute ESGSearch queries on a Globus Search Index.",
-        description="# Long form CommonMark content\n---\nTODO: source this from the same place as the python package description?",
         lifespan=token_renewal_watchdog,
     )
 

--- a/src/esg_fastapi/api/routes.py
+++ b/src/esg_fastapi/api/routes.py
@@ -1,14 +1,11 @@
 """API routes for version 1 of the ESG search Bridge API."""
 
 import logging
-from collections.abc import Generator
-from contextvars import ContextVar
-from typing import Any
+from typing import Annotated
 
-from fastapi.datastructures import URL
 import httpx
 import pyroscope
-from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import RedirectResponse
 from opentelemetry import trace
 from starlette import status
@@ -26,42 +23,34 @@ logger = logging.getLogger()
 router = APIRouter()
 
 
-tracing_tags = ContextVar("tracing_tags")
 
-
-def query_instrumentor(query: ESGSearchQuery = Depends()) -> Generator[ESGSearchQuery, Any, None]:
-    """Instruments the query with tracing tags and pyroscope tags."""
-    current_span: trace.Span = trace.get_current_span()
-    tracing_tags.set({key: str(value) for key, value in query.model_dump(exclude_none=True).items()})
-    current_span.set_attributes(tracing_tags.get())
-    with pyroscope.tag_wrapper(tracing_tags.get()):
-        yield query
-
-
-TrackedESGSearchQuery: ESGSearchQuery = Depends(query_instrumentor)
-
-
-def cache_control_response(response: Response) -> None:
+def set_cache_control_headers(response: Response) -> None:
     """Set the cache-control directives for the response."""
     response.headers["cache-control"] = "public max-age=300 stale-while-revalidate=300 stale-if-error=300"
 
 
+CacheControlHeaders = Depends(set_cache_control_headers)
+
+
 def validate_cache_request_directives(response: httpx.Response, headers: Headers) -> None:
     """If the response was cached, check for cache-control directives that have require responses."""
-    if response.extensions["from_cache"]:
-        logger.debug("Cached response found")
-        if client_etag := headers.get("if-none-match"):
-            logger.debug("Client sent if-none-match etag header")
-            if response.extensions["cache_metadata"]["cache_key"] == client_etag:
-                logger.debug("Client etag matched")
-                raise HTTPException(status.HTTP_304_NOT_MODIFIED)
+    if not response.extensions["from_cache"]:
+        return
 
-        elif client_etag := headers.get("if-match"):
-            logger.debug("Client sent if-match etag header")
-            logger.debug(f"{client_etag} vs {response.extensions['cache_metadata']['cache_key']}")
-            if response.extensions["cache_metadata"]["cache_key"] != client_etag:
-                logger.debug("Client etag did not match")
-                raise HTTPException(status.HTTP_412_PRECONDITION_FAILED)
+    cache_key = response.extensions["cache_metadata"]["cache_key"]
+    logger.debug(f"Cached response found for {cache_key}")
+
+    if client_etag := headers.get("if-none-match"):
+        logger.debug(f"Client sent if-none-match etag header {client_etag} vs {cache_key}")
+        if cache_key == client_etag:
+            logger.debug("Client etag matched")
+            raise HTTPException(status.HTTP_304_NOT_MODIFIED)
+
+    elif client_etag := headers.get("if-match"):
+        logger.debug(f"Client sent if-match etag header {client_etag} vs {cache_key}")
+        if cache_key != client_etag:
+            logger.debug("Client etag did not match")
+            raise HTTPException(status.HTTP_412_PRECONDITION_FAILED)
 
 
 WITHOUT_ROWS = {"limit": 0}
@@ -70,65 +59,33 @@ WITHOUT_FACETS = {"facets": []}
 
 @router.get("/search")
 async def search(request: Request) -> RedirectResponse:
-    """Redirects to the root path esgf-pyclient compatibility."""
+    """Redirects to the root path for esgf-pyclient compatibility."""
     destination = request.url_for("root").include_query_params(**request.query_params)
     return RedirectResponse(destination, status_code=status.HTTP_308_PERMANENT_REDIRECT)
 
 
-@router.get("/", name="root", response_model=ESGSearchResponse, dependencies=[Depends(cache_control_response)])
-async def search_globus(request: Request, q: ESGSearchQuery = TrackedESGSearchQuery) -> ESGSearchResponse:
-    """This function performs a search using the Globus API based on the provided ESG search query.
+@router.get("/", name="root", response_model=ESGSearchResponse, dependencies=[CacheControlHeaders])
+async def search_globus(request: Request, q: Annotated[ESGSearchQuery, Query()]) -> ESGSearchResponse:
+    """Allows searching the ESGF Globus Index using the same query requests and responses as the old Solr based ESG Search application."""
+    tags = {key: str(value) for key, value in q.model_dump(exclude_none=True).items()}
+    trace.get_current_span().set_attributes(tags)
+    with pyroscope.tag_wrapper(tags):
+        globus_query = GlobusSearchQuery.from_esg_search_query(q)
 
-    Parameters:
-    - q (ESGSearchQuery): The ESG search query object.
+        # Globus Search is orders of magnitude faster when searching for rows or facets only vs rows and facets.
+        # Its faster to do two separate queries and combine the results
+        rows_query = globus_query.model_copy(update=WITHOUT_FACETS)
+        rows_response = await request.app.globus_client.search(rows_query)
 
-    Returns:
-    - ESGSearchResponse: A response object containing the search results from the Globus API.
+        validate_cache_request_directives(rows_response, request.headers)
 
-    The function first constructs a Globus search query from the ESG query. It then sends a POST request to the Globus search endpoint with the constructed query.
+        response_json = rows_response.json()
 
-    The function then constructs a response object from the received data, adhering to the format returned by ESG Search.
+        if globus_query.facets:
+            facets_query = globus_query.model_copy(update=WITHOUT_ROWS)
+            facets_response = await request.app.globus_client.search(facets_query)
+            response_json["facet_results"] = facets_response.json()["facet_results"]
 
-    The response object contains the following fields:
-    - responseHeader: Contains information about the search query and its execution, such as the query time and the number of returned results.
-    - response: Contains the actual search results, including the total number of results, the starting offset, and the actual search results.
-    - facet_counts: Contains the counts of distinct values for each facet in the search results.
-    """
-    globus_query = GlobusSearchQuery.from_esg_search_query(q)
+        globus_result = GlobusSearchResult.model_validate(response_json)
 
-    # Globus Search is orders of magnitude faster when searching for rows or facets only vs rows and facets.
-    # Its faster to do two separate queries and combine the results
-    rows_query = globus_query.model_copy(update=WITHOUT_FACETS)
-    rows_response = await request.app.globus_client.search(rows_query)
-
-    validate_cache_request_directives(rows_response, request.headers)
-
-    response_json = rows_response.json()
-
-    if globus_query.facets:
-        facets_query = globus_query.model_copy(update=WITHOUT_ROWS)
-        facets_response = await request.app.globus_client.search(facets_query)
-        response_json["facet_results"] = facets_response.json()["facet_results"]
-
-    globus_result = GlobusSearchResult.model_validate(response_json)
-
-    return ESGSearchResponse.model_validate(
-        {
-            "responseHeader": {
-                "QTime": rows_response.extensions["globus_timings"]["total"],
-                "params": {
-                    "q": q.query,
-                    "start": q.offset,
-                    "rows": q.limit,
-                    "fq": q,
-                    "shards": f"esgf-data-node-solr-query:8983/solr/{q.type.lower()}s",
-                },
-            },
-            "response": {
-                "numFound": globus_result.total,
-                "start": globus_result.offset,
-                "docs": globus_result.gmeta,
-            },
-            "facet_counts": globus_result.facet_results,
-        }
-    )
+        return ESGSearchResponse.from_results(q, rows_response.extensions["globus_timings"]["total"], globus_result)

--- a/src/esg_fastapi/api/types.py
+++ b/src/esg_fastapi/api/types.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, Any, ForwardRef, Literal, TypedDict
 
 from annotated_types import T
@@ -16,13 +17,13 @@ else:
     GlobusFilter = ForwardRef("GlobusFilter")
 
 
-Stringified = Annotated[T, AfterValidator(lambda x: str(x))]
+Stringified = Annotated[T, PlainSerializer(str)]
 """String representation of the parameterized type."""
 
 MultiValued = Annotated[list[T], BeforeValidator(ensure_list), Query()]
 """Solr MultiValued Field of the parameterized type."""
 
-LowerCased = Annotated[T, PlainSerializer(lambda x: x.lower())]
+LowerCased = Annotated[T, PlainSerializer(lambda x: str(x).lower())]
 """Lower-case string representation of the parameterized type."""
 
 SupportedAsFacets = str | Sequence[GlobusFacet]
@@ -34,14 +35,15 @@ SupportedAsFilters = dict | Sequence[GlobusFilter]
 SolrFQ = str | Sequence[str]
 """Presentation type for the Solr `fq` field."""
 
-SupportedAsFQ = ESGSearchQuery | SolrFQ
-"""Represents types convertable to SolrFQ objects."""
-
 # TODO: we should be able to better specify the typing of docs
 SolrDoc = dict[str, Any]
 
-SupportedAsSolrDocs = SolrDoc | Sequence[GlobusMetaResult]
-"""Represents types convertable to a list of GlobusMetaResult objects."""
+SolrDatetime = Annotated[datetime, PlainSerializer(lambda x: x.strftime("%Y-%m-%dT%H:%M:%SZ")), Query()]
+
+FacetName = str
+FacetValue = str
+FacetValueCount = int
+ESGSearchFacetField = dict[FacetName, tuple[FacetValue | FacetValueCount, ...]]
 
 
 class GlobusToken(TypedDict):

--- a/tests/fixtures/from_and_to_query.json
+++ b/tests/fixtures/from_and_to_query.json
@@ -1,0 +1,69 @@
+{
+  "request": "format=application%2Fsolr%2Bjson&type=Dataset&from=2025-06-18T00:00:00Z&to=2025-06-20T00:00:00Z",
+  "globus_query": {
+    "q": null,
+    "advanced": true,
+    "limit": 0,
+    "offset": 0,
+    "filters": [
+      {
+        "type": "match_any",
+        "field_name": "type",
+        "values": ["Dataset"]
+      },
+      {
+        "type": "range",
+        "field_name": "_timestamp",
+        "values": [{ "from": "2025-06-18 00:00:00", "to": "2025-06-20 00:00:00" }]
+      }
+    ],
+    "facets": null
+  },
+  "globus_response": {
+    "gmeta": [],
+    "facet_results": null,
+    "offset": 0,
+    "count": 0,
+    "total": 9130715,
+    "has_next_page": true
+  },
+  "esg_search_response": {
+    "responseHeader": {
+      "status": 0,
+      "QTime": 2,
+      "params": {
+        "df": "text",
+        "q.alt": "*:*",
+        "indent": "true",
+        "echoParams": "all",
+        "fl": "*,score",
+        "start": "0",
+        "fq": "type:Dataset",
+        "rows": "0",
+        "q": "_timestamp:[2025-06-18T00:00:00Z TO 2025-06-20T00:00:00Z]",
+        "shards": "esgf-data-node-solr-query:8983/solr/datasets",
+        "tie": "0.01",
+        "facet.limit": "-1",
+        "qf": "text",
+        "facet.method": "enum",
+        "facet.mincount": "1",
+        "facet": "true",
+        "wt": "json",
+        "facet.sort": "lex"
+      }
+    },
+    "response": {
+      "numFound": 9130715,
+      "start": 0,
+      "docs": [],
+      "maxScore": null
+    },
+    "facet_counts": {
+      "facet_queries": {},
+      "facet_fields": {},
+      "facet_ranges": {},
+      "facet_intervals": {},
+      "facet_heatmaps": {}
+    }
+  }
+}

--- a/tests/fixtures/from_query.json
+++ b/tests/fixtures/from_query.json
@@ -1,0 +1,69 @@
+{
+  "request": "format=application%2Fsolr%2Bjson&type=Dataset&from=2025-06-18",
+  "globus_query": {
+    "q": null,
+    "advanced": true,
+    "limit": 0,
+    "offset": 0,
+    "filters": [
+      {
+        "type": "match_any",
+        "field_name": "type",
+        "values": ["Dataset"]
+      },
+      {
+        "type": "range",
+        "field_name": "_timestamp",
+        "values": [{ "from": "2025-06-18 00:00:00", "to": "*" }]
+      }
+    ],
+    "facets": null
+  },
+  "globus_response": {
+    "gmeta": [],
+    "facet_results": null,
+    "offset": 0,
+    "count": 0,
+    "total": 9130715,
+    "has_next_page": true
+  },
+  "esg_search_response": {
+    "responseHeader": {
+      "status": 0,
+      "QTime": 2,
+      "params": {
+        "df": "text",
+        "q.alt": "*:*",
+        "indent": "true",
+        "echoParams": "all",
+        "fl": "*,score",
+        "start": "0",
+        "fq": "type:Dataset",
+        "rows": "0",
+        "q": "_timestamp:[2025-06-18T00:00:00Z TO *]",
+        "shards": "esgf-data-node-solr-query:8983/solr/datasets",
+        "tie": "0.01",
+        "facet.limit": "-1",
+        "qf": "text",
+        "facet.method": "enum",
+        "facet.mincount": "1",
+        "facet": "true",
+        "wt": "json",
+        "facet.sort": "lex"
+      }
+    },
+    "response": {
+      "numFound": 9130715,
+      "start": 0,
+      "docs": [],
+      "maxScore": null
+    },
+    "facet_counts": {
+      "facet_queries": {},
+      "facet_fields": {},
+      "facet_ranges": {},
+      "facet_intervals": {},
+      "facet_heatmaps": {}
+    }
+  }
+}

--- a/tests/fixtures/max_version_query.json
+++ b/tests/fixtures/max_version_query.json
@@ -1,0 +1,69 @@
+{
+  "request": "format=application%2Fsolr%2Bjson&type=Dataset&max_version=20250618",
+  "globus_query": {
+    "q": null,
+    "advanced": true,
+    "limit": 0,
+    "offset": 0,
+    "filters": [
+      {
+        "type": "match_any",
+        "field_name": "type",
+        "values": ["Dataset"]
+      },
+      {
+        "type": "range",
+        "field_name": "version",
+        "values": [{ "from": "*", "to": 20250618 }]
+      }
+    ],
+    "facets": null
+  },
+  "globus_response": {
+    "gmeta": [],
+    "facet_results": null,
+    "offset": 0,
+    "count": 0,
+    "total": 9130715,
+    "has_next_page": true
+  },
+  "esg_search_response": {
+    "responseHeader": {
+      "status": 0,
+      "QTime": 2,
+      "params": {
+        "df": "text",
+        "q.alt": "*:*",
+        "indent": "true",
+        "echoParams": "all",
+        "fl": "*,score",
+        "start": "0",
+        "fq": "type:Dataset",
+        "rows": "0",
+        "q": "version:[* TO 20250618]",
+        "shards": "esgf-data-node-solr-query:8983/solr/datasets",
+        "tie": "0.01",
+        "facet.limit": "-1",
+        "qf": "text",
+        "facet.method": "enum",
+        "facet.mincount": "1",
+        "facet": "true",
+        "wt": "json",
+        "facet.sort": "lex"
+      }
+    },
+    "response": {
+      "numFound": 9130715,
+      "start": 0,
+      "docs": [],
+      "maxScore": null
+    },
+    "facet_counts": {
+      "facet_queries": {},
+      "facet_fields": {},
+      "facet_ranges": {},
+      "facet_intervals": {},
+      "facet_heatmaps": {}
+    }
+  }
+}

--- a/tests/fixtures/min_and_max_version_query.json
+++ b/tests/fixtures/min_and_max_version_query.json
@@ -1,0 +1,69 @@
+{
+  "request": "format=application%2Fsolr%2Bjson&type=Dataset&min_version=20250618&max_version=20250620",
+  "globus_query": {
+    "q": null,
+    "advanced": true,
+    "limit": 0,
+    "offset": 0,
+    "filters": [
+      {
+        "type": "match_any",
+        "field_name": "type",
+        "values": ["Dataset"]
+      },
+      {
+        "type": "range",
+        "field_name": "version",
+        "values": [{ "from": 20250618, "to": 20250620 }]
+      }
+    ],
+    "facets": null
+  },
+  "globus_response": {
+    "gmeta": [],
+    "facet_results": null,
+    "offset": 0,
+    "count": 0,
+    "total": 9130715,
+    "has_next_page": true
+  },
+  "esg_search_response": {
+    "responseHeader": {
+      "status": 0,
+      "QTime": 2,
+      "params": {
+        "df": "text",
+        "q.alt": "*:*",
+        "indent": "true",
+        "echoParams": "all",
+        "fl": "*,score",
+        "start": "0",
+        "fq": "type:Dataset",
+        "rows": "0",
+        "q": "version:[20250618 TO *] AND version:[* TO 20250620]",
+        "shards": "esgf-data-node-solr-query:8983/solr/datasets",
+        "tie": "0.01",
+        "facet.limit": "-1",
+        "qf": "text",
+        "facet.method": "enum",
+        "facet.mincount": "1",
+        "facet": "true",
+        "wt": "json",
+        "facet.sort": "lex"
+      }
+    },
+    "response": {
+      "numFound": 9130715,
+      "start": 0,
+      "docs": [],
+      "maxScore": null
+    },
+    "facet_counts": {
+      "facet_queries": {},
+      "facet_fields": {},
+      "facet_ranges": {},
+      "facet_intervals": {},
+      "facet_heatmaps": {}
+    }
+  }
+}

--- a/tests/fixtures/min_version_query.json
+++ b/tests/fixtures/min_version_query.json
@@ -1,0 +1,69 @@
+{
+  "request": "format=application%2Fsolr%2Bjson&type=Dataset&min_version=20250618",
+  "globus_query": {
+    "q": null,
+    "advanced": true,
+    "limit": 0,
+    "offset": 0,
+    "filters": [
+      {
+        "type": "match_any",
+        "field_name": "type",
+        "values": ["Dataset"]
+      },
+      {
+        "type": "range",
+        "field_name": "version",
+        "values": [{ "from": 20250618, "to": "*" }]
+      }
+    ],
+    "facets": null
+  },
+  "globus_response": {
+    "gmeta": [],
+    "facet_results": null,
+    "offset": 0,
+    "count": 0,
+    "total": 9130715,
+    "has_next_page": true
+  },
+  "esg_search_response": {
+    "responseHeader": {
+      "status": 0,
+      "QTime": 2,
+      "params": {
+        "df": "text",
+        "q.alt": "*:*",
+        "indent": "true",
+        "echoParams": "all",
+        "fl": "*,score",
+        "start": "0",
+        "fq": "type:Dataset",
+        "rows": "0",
+        "q": "version:[20250618 TO *]",
+        "shards": "esgf-data-node-solr-query:8983/solr/datasets",
+        "tie": "0.01",
+        "facet.limit": "-1",
+        "qf": "text",
+        "facet.method": "enum",
+        "facet.mincount": "1",
+        "facet": "true",
+        "wt": "json",
+        "facet.sort": "lex"
+      }
+    },
+    "response": {
+      "numFound": 9130715,
+      "start": 0,
+      "docs": [],
+      "maxScore": null
+    },
+    "facet_counts": {
+      "facet_queries": {},
+      "facet_fields": {},
+      "facet_ranges": {},
+      "facet_intervals": {},
+      "facet_heatmaps": {}
+    }
+  }
+}

--- a/tests/fixtures/to_query.json
+++ b/tests/fixtures/to_query.json
@@ -1,0 +1,69 @@
+{
+  "request": "format=application%2Fsolr%2Bjson&type=Dataset&to=2025-06-20",
+  "globus_query": {
+    "q": null,
+    "advanced": true,
+    "limit": 0,
+    "offset": 0,
+    "filters": [
+      {
+        "type": "match_any",
+        "field_name": "type",
+        "values": ["Dataset"]
+      },
+      {
+        "type": "range",
+        "field_name": "_timestamp",
+        "values": [{ "from": "*", "to": "2025-06-20 00:00:00" }]
+      }
+    ],
+    "facets": null
+  },
+  "globus_response": {
+    "gmeta": [],
+    "facet_results": null,
+    "offset": 0,
+    "count": 0,
+    "total": 9130715,
+    "has_next_page": true
+  },
+  "esg_search_response": {
+    "responseHeader": {
+      "status": 0,
+      "QTime": 2,
+      "params": {
+        "df": "text",
+        "q.alt": "*:*",
+        "indent": "true",
+        "echoParams": "all",
+        "fl": "*,score",
+        "start": "0",
+        "fq": "type:Dataset",
+        "rows": "0",
+        "q": "_timestamp:[* TO 2025-06-20T00:00:00Z]",
+        "shards": "esgf-data-node-solr-query:8983/solr/datasets",
+        "tie": "0.01",
+        "facet.limit": "-1",
+        "qf": "text",
+        "facet.method": "enum",
+        "facet.mincount": "1",
+        "facet": "true",
+        "wt": "json",
+        "facet.sort": "lex"
+      }
+    },
+    "response": {
+      "numFound": 9130715,
+      "start": 0,
+      "docs": [],
+      "maxScore": null
+    },
+    "facet_counts": {
+      "facet_queries": {},
+      "facet_fields": {},
+      "facet_ranges": {},
+      "facet_intervals": {},
+      "facet_heatmaps": {}
+    }
+  }
+}

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -18,7 +18,7 @@ EtagHeader = dict[EtagMatchType, str]
 @given(parse("that the client provides an <{header_match}> etag"), target_fixture="etag_header")
 def create_request(header_match: EtagMatchType) -> EtagHeader:
     """Creates an ETag header dict with the value of the default empty query."""
-    return {header_match: "751ef835d1fcb35932af51f937204956"}
+    return {header_match: "407815320a2e84179231891ac0d66e37"}
 
 
 @when("the result for that etag is cached")


### PR DESCRIPTION
- This fixes #73 on our side, but the `version` field in the Globus Search Index was "auto detected" as a string instead of a date so range filters won't work on the field. Changing the field type [will require a full reindex of all data in the index](https://docs.globus.org/api/search/mapped_data_types/#changing_the_type_of_indexed_data).
- Fixes #55 Supports temporal querying via the `from` and `to` parameters over the `_timestamp` field
- Fixes #88 They now return the appropriate HTTP 422 response
- Cleaned up and clarified modeling
- Fixed issue where generated OpenAPI docs weren't properly pulling documentation from doc strings and then weren't being displayed due to a bug in the FastAPI dependency system (?)